### PR TITLE
expose fullNumber of field state

### DIFF
--- a/lib/src/form_builder_phone_field.dart
+++ b/lib/src/form_builder_phone_field.dart
@@ -294,11 +294,18 @@ class FormBuilderPhoneField extends FormBuilderFieldDecoration<String> {
       createState() => _FormBuilderPhoneFieldState();
 }
 
+abstract class FormBuilderPhoneFieldState {
+  String get fullNumber;
+} 
+
 class _FormBuilderPhoneFieldState
-    extends FormBuilderFieldDecorationState<FormBuilderPhoneField, String> {
+    extends FormBuilderFieldDecorationState<FormBuilderPhoneField, String>
+    implements FormBuilderPhoneFieldState {
+  
   late TextEditingController _effectiveController;
   late Country _selectedDialogCountry;
 
+  @override
   String get fullNumber {
     // When there is no phone number text, the field is empty -- the country
     // prefix is only prepended when a phone number is specified.


### PR DESCRIPTION
expose fullNumber to allow access over FormBuilderState:

```dart
(formKey.currentState!.fields['phoneField'] as FormBuilderPhoneFieldState).fullNumber
```

Currently there is no way to access the valid full number of a `FormBuilderPhoneField`'s current state over a `FormBuilderState` **in a safe manner**, whereas we can access the (full) state value of all other form builder fields.