### PR TITLE
dependency update to support flutter 3.22.0 +

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -48,7 +48,7 @@ android {
         applicationId "dev.danvickmiller.example"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion 16
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -28,7 +28,7 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 flutter_ios_podfile_setup
 
 target 'Runner' do
-  pod 'PhoneNumberKit/PhoneNumberKitCore', :git => 'https://github.com/marmelroy/PhoneNumberKit', :tag => '3.6.0'
+  pod 'PhoneNumberKit/PhoneNumberKitCore', :git => 'https://github.com/marmelroy/PhoneNumberKit', :tag => '3.6.6'
   use_frameworks!
   use_modular_headers!
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -28,7 +28,7 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 flutter_ios_podfile_setup
 
 target 'Runner' do
-  pod 'PhoneNumberKit/PhoneNumberKitCore', :git => 'https://github.com/marmelroy/PhoneNumberKit', :tag => '3.5.8'
+  pod 'PhoneNumberKit/PhoneNumberKitCore', :git => 'https://github.com/marmelroy/PhoneNumberKit', :tag => '3.6.0'
   use_frameworks!
   use_modular_headers!
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,7 +9,7 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -36,7 +36,7 @@ class MyApp extends StatelessWidget {
 class MyHomePage extends StatelessWidget {
   final _formKey = GlobalKey<FormBuilderState>();
 
-  MyHomePage({Key? key}) : super(key: key);
+  MyHomePage({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -74,10 +74,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      sha256: "3f41d009ba7172d5ff9be5f6e6e6abb4300e263aab8866d2a0842ed2a70f8f0c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "4.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -139,10 +139,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "6b0206b0bf4f04961fc5438198ccb3a885685cd67d4d4a32cc20ad7f8adbe015"
+      sha256: "976c774dd944a42e83e2467f4cc670daef7eed6295b10b36ae8c85bcbf828235"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "4.0.0"
   matcher:
     dependency: transitive
     description:
@@ -179,10 +179,10 @@ packages:
     dependency: transitive
     description:
       name: phone_number
-      sha256: aa96cfca02bbe728a11d13a9f9f7d25a1b68d094c36c3bd18ce959d476a1c9f3
+      sha256: c66d3e2f2c69ce95f10bb923957049b1e5b8c6efea02d7366353fa3b80d4338a
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,6 +5,7 @@ version: 1.0.0+1
 
 environment:
   sdk: ">=3.3.0 <4.0.0"
+  flutter: ">=3.22.0"
 
 dependencies:
   flutter:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,8 +4,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.10.0"
+  sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
   flutter:
@@ -18,7 +17,7 @@ dependencies:
   form_builder_validators: ^10.0.1
   
 dev_dependencies:
-  flutter_lints: ^2.0.1
+  flutter_lints: ^4.0.0
   flutter_test:
     sdk: flutter
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_form_builder: ^9.3.0
-  phone_number: ^2.0.0
+  phone_number: ^2.1.0
   country_pickers: ^3.0.1
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ funding:
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.10.0"
+  flutter: ">=3.22.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #[62](https://github.com/flutter-form-builder-ecosystem/form_builder_phone_field/issues/62)

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->
Connected Flutter 3.22.0 +

## Solution description
Updated child dependency

- phone_number: ^2.1.0
- flutter_lints: ^4.0.0
- dart sdk: ">=3.3.0 <4.0.0"


